### PR TITLE
Oro Platform 4 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installation Instructions
 
 1. Clear cache
         
-        php app/console cache:clear --env=prod
+        php bin/console cache:clear --env=prod
         
 AWS Setup
 ---------
@@ -83,10 +83,12 @@ Initial version by Adam Hall <adam.hall@aligent.com.au>.
 
 Minor tweaks for OroCommerce 3.0 by Jim O'Halloran <jim@aligent.com.au>
 
+Update for Oro Platform 4.0 by Jim O'Halloran <jim.ohalloran@incore.com.au>
+
 Licence
 -------
 [OSL - Open Software Licence 3.0](http://opensource.org/licenses/osl-3.0.php)
 
 Copyright
 ---------
-(c) 2018 Aligent Consulting
+(c) 2018-19 Aligent Consulting

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-Amazon S3 Media Storage Bundle for OroCommerce
-==============================================
+Amazon S3 Media Storage Bundle for Oro Platform
+===============================================
 
 Facts
 -----
-- version: 1.0.0
+- version: 2.0.0
 - composer name: aligent/orocommerce-s3mediabundle
 
 Description
 -----------
 
-This bundle provides configuration for using S3 buckets for media storage in OroCommerce 
-by configuring the KNPGaufrette Bundle.  It could also be used in OroCRM with changes to 
-Gaufrette's filesystem names in app.yml.
+This bundle provides configuration for using S3 buckets for media storage in Oro Platform 
+by configuring the KNPGaufrette Bundle.  It will work with both OroCommerce and OroCRM 
+versions based on Oro Platform 4.0.0 and later.  For older versions pf OroCommerce use one 
+of the 1.x releases of this module.
 
 ### Parameters
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "oro/commerce": "3.*",
+        "oro/platform": ">=4.0",
         "gaufrette/aws-s3-adapter": "^0.4.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "name": "aligent/orocommerce-s3mediabundle",
-    "version": "1.1.0",
-    "description": "Amazon S3 Based media storage for OroCommerce",
+    "version": "2.0.0",
+    "description": "Amazon S3 Based media storage for Oro Platform (OroCommerce and OroCRM)",
     "homepage": "https://github.com/aligent/orocommerce-s3mediabundle",
-    "keywords": ["Oro", "OroCommerce", "Amazon", "S3", "AWS"],
+    "keywords": ["Oro", "OroPlatform", "OroCommerce", "OroCRM", "Amazon", "S3", "AWS"],
     "license": "OSL-3.0",
     "authors": [
         {

--- a/src/LICENSE
+++ b/src/LICENSE
@@ -2,6 +2,6 @@ Aligent S3MediaBundle
 
 The Open Software License version 3.0
 
-Copyright (c) 2018, Aligent Consulting.
+Copyright (c) 2018-2019, Aligent Consulting.
 
 Full license is at: http://opensource.org/licenses/OSL-3.0

--- a/src/Resources/config/oro/app.yml
+++ b/src/Resources/config/oro/app.yml
@@ -6,19 +6,19 @@ knp_gaufrette:
                 service_id: 'aligent_s3.client'
                 bucket_name: '%amazon_s3.bucket_name%'
                 options:
-                    directory:  '%oro_attachment.attachments_dir%'
+                    directory:  '%oro_attachment.filesystem_dir.attachments%'
                     create: true
 
         mediacache_local:
             local:
-                directory: "%kernel.root_dir%/../public/%oro_attachment.media_cache_dir%"
+                directory: '%kernel.project_dir%/public/%oro_attachment.filesystem_dir.mediacache%'
                 create: true
         s3_mediacache:
             aws_s3:
                 service_id: 'aligent_s3.client'
                 bucket_name: '%amazon_s3.bucket_name%'
                 options:
-                    directory:  '%oro_attachment.media_cache_dir%'
+                    directory:  '%oro_attachment.filesystem_dir.mediacache%'
                     create: true
         mediacache_cache:
             cache:
@@ -26,8 +26,27 @@ knp_gaufrette:
               cache: mediacache_local
               ttl: 86400
 
+        protected_mediacache_local:
+            local:
+                directory: '%kernel.project_dir%/var/%oro_attachment.filesystem_dir.protected_mediacache%'
+                create: true
+        s3_protected_mediacache:
+            aws_s3:
+                service_id: 'aligent_s3.client'
+                bucket_name: '%amazon_s3.bucket_name%'
+                options:
+                    directory:  '%oro_attachment.filesystem_dir.protected_mediacache%'
+                    create: true
+        protected_mediacache_cache:
+            cache:
+              source: s3_protected_mediacache
+              cache: protected_mediacache_local
+              ttl: 86400
+
     filesystems:
         attachments:
             adapter: s3_attachments
         mediacache:
             adapter: mediacache_cache
+        protected_mediacache:
+            adapter: protected_mediacache_cache


### PR DESCRIPTION
This branch adds compatibility for Oro Platform 4, which allows the module to be used on OroCRM 4 as well as OroCommerce.

Note: Because of a backwards incompatible change in Platform 4.x this is no longer compatible with prior versions of Platform.  Consequently, I've bumped the version number to 2.0.0 and added a note to the README to the effect that installations using earlier versions of Oro Platform should use one of the 1.x releases.