### PR TITLE
Added Command to migrate images to new file path required by OroCommerce Enterprise to 3.1.12, 4.1 or 1.6.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Amazon S3 Media Storage Bundle for OroCommerce
 
 Facts
 -----
-- version: 1.0.0
+- version: 1.1.1
 - composer name: aligent/orocommerce-s3mediabundle
 
 Description
@@ -65,6 +65,20 @@ bucket's name:
 Secret keys.  Insert those values into your parameters.yml (see above), clear 
 cache and you're good to go!
 
+Upgrading OroCommerce Enterprise to 3.1.12, 4.1 or 1.6.45
+-------
+Oro have migrated the media cache directory structure so that images with the same filters will be shared across websites, reducing the size of the media cache.
+Unfortunately if you have a large amount of images stored on S3 using this bundle the core Migration can take a LONG time to migrate to the new structure.
+We have provided a command that can be run locally to copy the images to the new directory structure. This way you can pre-move the images and manually mark that migration as being run.
+
+Usage:
+```
+$ bin/console aligent:s3:migrate-website-images bianco-hardware-media AWS_KEY AWS_SECRET ap-southeast-2 --env=prod
+```
+
+Once the images have been copied to the new path, you can mark the core Oro\Bundle\MultiWebsiteBundle\Migrations\Data\ORM\MigrateFilteredAttachments data migration has run in the database and deploy the new version.
+After the deploy is complete, you can delete all the images from their old path.
+ 
 Support
 -------
 If you have any issues with this bundle, please create a 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We have provided a command that can be run locally to copy the images to the new
 
 Usage:
 ```
-$ bin/console aligent:s3:migrate-website-images bianco-hardware-media AWS_KEY AWS_SECRET ap-southeast-2 --env=prod
+$ bin/console aligent:s3:migrate-website-images some-bucket-name AWS_KEY AWS_SECRET ap-southeast-2 --env=prod
 ```
 
 Once the images have been copied to the new path, you can mark the core Oro\Bundle\MultiWebsiteBundle\Migrations\Data\ORM\MigrateFilteredAttachments data migration has run in the database and deploy the new version.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aligent/orocommerce-s3mediabundle",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Amazon S3 Based media storage for OroCommerce",
     "homepage": "https://github.com/aligent/orocommerce-s3mediabundle",
     "keywords": ["Oro", "OroCommerce", "Amazon", "S3", "AWS"],

--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -31,7 +31,6 @@ class AwsS3 extends BaseAdapter
             $options['Prefix'] = $this->options['directory'];
         }
 
-        $keys = [];
         $iter = $this->service->getIterator('ListObjects', $options);
 
         return $iter;

--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *
+ *
+ * @category  Aligent
+ * @package
+ * @author    Adam Hall <adam.hall@aligent.com.au>
+ * @copyright 2019 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\S3MediaBundle\Adapter;
+
+use Gaufrette\Adapter\AwsS3 as BaseAdapter; 
+class AwsS3 extends BaseAdapter
+{
+
+    /**
+     * Returns a key iterator 
+     * @return \Iterator
+     */
+    public function getKeyIterator($prefix)
+    {
+        $this->ensureBucketExists();
+
+        $options = ['Bucket' => $this->bucket];
+        if ((string) $prefix != '') {
+            $options['Prefix'] = $this->computePath($prefix);
+        } elseif (!empty($this->options['directory'])) {
+            $options['Prefix'] = $this->options['directory'];
+        }
+
+        $keys = [];
+        $iter = $this->service->getIterator('ListObjects', $options);
+
+        return $iter;
+    }
+
+    /**
+     * Computes the key from the specified path.
+     *
+     * @param string $path
+     *
+     * return string
+     */
+    public function computeKey($path)
+    {
+        return parent::computeKey($path);
+    }
+    
+    /*
+     * Copies the file at $originalFilePath to $newFilePath
+     */
+    public function copy($originalFilePath, $newFilePath)
+    {
+        $this->service->copy($this->bucket, $originalFilePath, $this->bucket, $newFilePath);
+    }
+}

--- a/src/AligentS3MediaBundle.php
+++ b/src/AligentS3MediaBundle.php
@@ -13,6 +13,7 @@
 namespace Aligent\S3MediaBundle;
 
 use Aligent\S3MediaBundle\DependencyInjection\Compiler\ChainCredentialsProviderPass;
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Command/WebsiteImageMigrationCommand.php
+++ b/src/Command/WebsiteImageMigrationCommand.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ *
+ * @category  Aligent
+ * @package
+ * @author    Adam Hall <adam.hall@aligent.com.au>
+ * @copyright 2019 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\S3MediaBundle\Command;
+
+
+use Aligent\S3MediaBundle\Adapter\AwsS3;
+use Aligent\S3MediaBundle\Service\FilteredAttachmentMigrationService;
+use Gaufrette\Filesystem;
+use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Oro\Bundle\WebsiteBundle\Entity\Website;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Aws\S3\S3Client;
+
+class WebsiteImageMigrationCommand extends ContainerAwareCommand
+{
+    protected const PREFIX = 'media/cache/attachment/filter';
+    protected static $defaultName = 'aligent:s3:migrate-website-images';
+
+    /**
+     *
+     */
+    protected function configure()
+    {
+        $this->setDescription('Copies Website images to the new location required by Oro 3.1.12')
+            ->addArgument('bucket', InputArgument::REQUIRED, 'Which S3 Bucket do you want to migrate?')
+            ->addArgument('key', InputArgument::REQUIRED, 'Amazon API Key')
+            ->addArgument('secret', InputArgument::REQUIRED, 'Amazon API Secret')
+            ->addArgument('region', InputArgument::REQUIRED, 'Amazon Bucket Region');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $s3client = new S3Client([
+            'credentials' => [
+                'key'     => $input->getArgument('key'),
+                'secret'  => $input->getArgument('secret'),
+            ],
+            'version' => 'latest',
+            'region'  => $input->getArgument('region')
+        ]);
+        
+        $adapter = new AwsS3($s3client, $input->getArgument('bucket'));
+        
+        /** @var FilteredAttachmentMigrationService $migrationService */
+        $migrationService = $this->getContainer()->get('aligent_s3.attachment_migration_service');
+
+        $websiteRepo = $this->getContainer()->get('doctrine')->getRepository(Website::class);
+        $websites = $websiteRepo->getAllWebsites();
+        $websiteManager = $this->getContainer()->get('oro_website.manager');
+        $configManager = $this->getContainer()->get('oro_config.website');
+
+        $websiteIds = [];
+        foreach ($websites as $website) {
+            $output->writeln('Migrating images for website: ' . $website->getName());
+            $websiteId = $website->getId();
+            $websiteIds[] = $websiteId;
+            $websiteManager->setCurrentWebsite($website);
+            $configManager->setScopeId($websiteId);
+            
+            $migrationService->migrate($adapter, self::PREFIX . '/' . $websiteId, self::PREFIX);
+        }
+
+        $output->writeln('Images have been successfully copied to the new destination.');
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -40,3 +40,10 @@ services:
                 version: latest
                 region: '%amazon_s3.region%'
                 credentials: "@aligent_s3.credentials"
+
+    # Migration Command Services:
+    aligent_s3.attachment_migration_service:
+        class: Aligent\S3MediaBundle\Service\FilteredAttachmentMigrationService
+        arguments:
+            - '@liip_imagine.filter.configuration'
+            - '@oro_layout.loader.image_filter'

--- a/src/Service/FilteredAttachmentMigrationService.php
+++ b/src/Service/FilteredAttachmentMigrationService.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This service is based on the core Oro\Bundle\AttachmentBundle\Migration\FilteredAttachmentMigrationService
+ * However it uses the extended S3 adapter provided by this bundle to instead copy the images to the new location
+ * the intent is that this is run locally prior to deployment so that the migration provided by the core
+ * can be skipped and after the deploy the images manually deleted.
+ *
+ * @category  Aligent
+ * @package
+ * @author    Adam Hall <adam.hall@aligent.com.au>
+ * @copyright 2019 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\S3MediaBundle\Service;
+
+
+use Aligent\S3MediaBundle\Adapter\AwsS3;
+use Knp\Bundle\GaufretteBundle\FilesystemMap;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Gaufrette\Filesystem;
+use Oro\Bundle\LayoutBundle\Loader\ImageFilterLoader;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FilteredAttachmentMigrationService
+{
+    /**
+     * @var FilterConfiguration
+     */
+    protected $filterConfiguration;
+
+    /**
+     * @var ImageFilterLoader
+     */
+    protected $filterLoader;
+
+    /**
+     * @var \Gaufrette\Filesystem
+     */
+    protected $fileSystem;
+
+    /**
+     * @param FilterConfiguration $filterConfiguration
+     * @param ImageFilterLoader $filterLoader
+     */
+    public function __construct(
+        FilterConfiguration $filterConfiguration,
+        ImageFilterLoader $filterLoader
+    ) {
+        $this->filterConfiguration = $filterConfiguration;
+        $this->filterLoader = $filterLoader;
+    }
+
+    /**
+     * @param string $fromPrefix
+     * @param string $toPrefix
+     * @return array
+     */
+    public function migrate(AwsS3 $adapter, string $fromPrefix, string $toPrefix)
+    {
+        $filterPathMap = $this->getFilterPathMap();
+
+        if (!$adapter->isDirectory($fromPrefix)) {
+            return [];
+        }
+
+        $pathRegEx = '/' . str_replace('/', '\/', $fromPrefix) . '\/(\d+)\/([^\/]+)\/([^\/]+)/';
+
+        $processedFiles = [];
+        foreach ($adapter->getKeyIterator($fromPrefix) as $key) {
+            $key = $adapter->computeKey($key['Key']);
+            
+            if (0 !== strpos($key, $fromPrefix) || $adapter->isDirectory($key)) {
+                continue;
+            }
+
+            $matches = [];
+            if (preg_match($pathRegEx, $key, $matches) !== 1) {
+                continue;
+            }
+
+            $fileId = $matches[1];
+            $filterName = $matches[2];
+            $fileName = $matches[3];
+
+            if (empty($filterPathMap[$filterName])) {
+                continue;
+            }
+
+            $newFilePath = $toPrefix . '/' . $filterPathMap[$filterName] . '/' . $fileId . '/' . $fileName;
+            if (!$adapter->exists($newFilePath)) {
+                $adapter->copy($key, $newFilePath);
+            }
+            $processedFiles[$fileId] = true;
+        }
+
+        return array_keys($processedFiles);
+    }
+
+    /**
+     * @return array
+     */
+    private function getFilterPathMap(): array
+    {
+        $filterMap = [];
+        $this->filterLoader->forceLoad();
+        foreach ($this->filterConfiguration->all() as $filterName => $config) {
+            $filterMap[$filterName] = $filterName . '/' . md5(json_encode($config));
+        }
+
+        return $filterMap;
+    }
+
+}


### PR DESCRIPTION
Added Extended Adapter to add a simple copy function
Added FilteredAttachmentMigrationService based on the core service to copy the files using the provided	S3 adapter instead of moving