### PR TITLE
Oro Platform 5.1 Compatibility

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPCS
@@ -36,6 +36,13 @@ jobs:
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-
+
+
+      - name: Configure Plugins flex
+        run: composer config --no-plugins allow-plugins.symfony/flex true
+
+      - name: Configure Plugins runtime
+        run: composer config --no-plugins allow-plugins.symfony/runtime true
 
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan
@@ -36,6 +36,13 @@ jobs:
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-
+
+
+      - name: Configure Plugins flex
+        run: composer config --no-plugins allow-plugins.symfony/flex true
+
+      - name: Configure Plugins runtime
+        run: composer config --no-plugins allow-plugins.symfony/runtime true
 
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPUnit
@@ -24,6 +24,12 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: "dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo"
           coverage: none
+
+      - name: Configure Plugins flex
+        run: composer config --no-plugins allow-plugins.symfony/flex true
+
+      - name: Configure Plugins runtime
+        run: composer config --no-plugins allow-plugins.symfony/runtime true
 
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/platform": "5.0.*",
+    "oro/platform": "5.1.*",
     "gaufrette/aws-s3-adapter": "^0.4.0",
-    "knplabs/gaufrette": "^0.10.0",
+    "knplabs/gaufrette": "^0.11",
     "aws/aws-sdk-php": "^3.17.0"
   },
   "require-dev": {

--- a/src/Cache/OroCacheAdapter.php
+++ b/src/Cache/OroCacheAdapter.php
@@ -2,14 +2,13 @@
 namespace Aligent\S3MediaBundle\Cache;
 
 use Aws\CacheInterface as AwsCacheInterface;
-use Doctrine\Common\Cache\Cache;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\CacheItem;
-use Symfony\Contracts\Cache\CacheInterface as SymfonyCacheInterface;
 
 class OroCacheAdapter implements AwsCacheInterface
 {
     public function __construct(
-        private SymfonyCacheInterface $cache
+        private AdapterInterface $cache
     ) {
     }
 
@@ -44,7 +43,7 @@ class OroCacheAdapter implements AwsCacheInterface
 
     public function remove($key)
     {
-        return $this->cache->delete($key);
+        return $this->cache->deleteItem($key);
     }
 
     public function delete($key)

--- a/src/Cache/OroCacheAdapter.php
+++ b/src/Cache/OroCacheAdapter.php
@@ -1,0 +1,59 @@
+<?php
+namespace Aligent\S3MediaBundle\Cache;
+
+use Aws\CacheInterface as AwsCacheInterface;
+use Doctrine\Common\Cache\Cache;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\CacheInterface as SymfonyCacheInterface;
+
+class OroCacheAdapter implements AwsCacheInterface
+{
+    public function __construct(
+        private SymfonyCacheInterface $cache
+    ) {
+    }
+
+    public function get($key)
+    {
+        /** @var CacheItem $cacheItem */
+        $cacheItem = $this->cache->getItem($key);
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        }
+        return null;
+    }
+
+    public function fetch($key)
+    {
+        return $this->get($key);
+    }
+
+    public function set($key, $value, $ttl = 0)
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($value)
+            ->expiresAfter($ttl === 0 ? null : $ttl);
+
+        return $this->cache->save($item);
+    }
+
+    public function save($key, $value, $ttl = 0)
+    {
+        return $this->set($key, $value, $ttl);
+    }
+
+    public function remove($key)
+    {
+        return $this->cache->delete($key);
+    }
+
+    public function delete($key)
+    {
+        return $this->remove($key);
+    }
+
+    public function contains($key)
+    {
+        return $this->cache->hasItem($key);
+    }
+}

--- a/src/DependencyInjection/Compiler/ChainCredentialsProviderPass.php
+++ b/src/DependencyInjection/Compiler/ChainCredentialsProviderPass.php
@@ -12,6 +12,7 @@
 
 namespace Aligent\S3MediaBundle\DependencyInjection\Compiler;
 
+use Aligent\S3MediaBundle\Provider\ChainCredentialsProvider;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,19 +20,18 @@ use Symfony\Component\VarDumper\VarDumper;
 
 class ChainCredentialsProviderPass implements CompilerPassInterface
 {
-    const TAG = 'aligent_s3.crendential_provider';
-    const CHAIN_SERVICE_ID = 'aligent_s3.credentials_provider.chain';
+    const TAG = 'aligent_s3.credential_provider';
 
     /**
      * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition(self::CHAIN_SERVICE_ID)) {
+        if (!$container->hasDefinition(ChainCredentialsProvider::class)) {
             return;
         }
 
-        $chainDefinition = $container->getDefinition(self::CHAIN_SERVICE_ID);
+        $chainDefinition = $container->getDefinition(ChainCredentialsProvider::class);
         $taggedServices = $container->findTaggedServiceIds(self::TAG);
 
 

--- a/src/Provider/ChainCredentialsProvider.php
+++ b/src/Provider/ChainCredentialsProvider.php
@@ -12,6 +12,7 @@
 
 namespace Aligent\S3MediaBundle\Provider;
 
+use Aws\CacheInterface;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\DoctrineCacheAdapter;
@@ -28,17 +29,12 @@ class ChainCredentialsProvider
     protected $providers = [];
 
     /**
-     * @var DoctrineCacheAdapter
-     */
-    protected $cache;
-
-    /**
      * ChainCredentialsProvider constructor.
-     * @param DoctrineCacheAdapter $cache
+     * @param CacheInterface $cache
      */
-    public function __construct(DoctrineCacheAdapter $cache)
+    public function __construct(
+        protected CacheInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Provider/ChainCredentialsProvider.php
+++ b/src/Provider/ChainCredentialsProvider.php
@@ -33,8 +33,8 @@ class ChainCredentialsProvider
      * @param CacheInterface $cache
      */
     public function __construct(
-        protected CacheInterface $cache)
-    {
+        protected CacheInterface $cache
+    ) {
     }
 
     /**

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -9,20 +9,19 @@ services:
         arguments:
             - '@aligent_s3.cache'
 
-    aligent_s3.credentials_provider.chain:
-        class: Aligent\S3MediaBundle\Provider\ChainCredentialsProvider
+    Aligent\S3MediaBundle\Provider\ChainCredentialsProvider:
         arguments:
             - '@Aligent\S3MediaBundle\Cache\OroCacheAdapter'
 
     aligent_s3.credentials:
         class: GuzzleHttp\Promise\PromiseInterface
-        factory: ['@aligent_s3.credentials_provider.chain', 'getCredentialChain']
+        factory: ['@Aligent\S3MediaBundle\Provider\ChainCredentialsProvider', 'getCredentialChain']
 
     aligent_s3.credentials_provider.ecs:
         class: Aws\Credentials\EcsCredentialProvider
         factory: ['Aws\Credentials\CredentialProvider', 'ecsCredentials']
         tags:
-            - { name: aligent_s3.crendential_provider }
+            - { name: aligent_s3.credential_provider }
 
     aligent_s3.credentials_provider.key:
         class: 'Aligent\S3MediaBundle\Provider\SecretKeyCredentialProvider'
@@ -30,7 +29,7 @@ services:
             - "@=container.hasParameter('amazon_s3.key') ? parameter('amazon_s3.key') : ''"
             - "@=container.hasParameter('amazon_s3.secret') ? parameter('amazon_s3.secret') : ''"
         tags:
-            - { name: aligent_s3.crendential_provider }
+            - { name: aligent_s3.credential_provider }
 
     aligent_s3.client:
         class: Aws\S3\S3Client

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,9 +1,9 @@
 services:
     aligent_s3.cache:
-        parent: oro.cache.abstract
+        parent: oro.data.cache
         public: false
-        calls:
-            - [ setNamespace, [ 'aligent_s3' ] ]
+        tags:
+          - { name: 'cache.pool', namespace: 'aligent_s3' }
 
     aligent_s3.cache_adapter:
         class: Aws\DoctrineCacheAdapter

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,15 +5,14 @@ services:
         tags:
           - { name: 'cache.pool', namespace: 'aligent_s3' }
 
-    aligent_s3.cache_adapter:
-        class: Aws\DoctrineCacheAdapter
+    Aligent\S3MediaBundle\Cache\OroCacheAdapter:
         arguments:
             - '@aligent_s3.cache'
 
     aligent_s3.credentials_provider.chain:
         class: Aligent\S3MediaBundle\Provider\ChainCredentialsProvider
         arguments:
-            - '@aligent_s3.cache_adapter'
+            - '@Aligent\S3MediaBundle\Cache\OroCacheAdapter'
 
     aligent_s3.credentials:
         class: GuzzleHttp\Promise\PromiseInterface

--- a/src/Tests/Unit/DependencyInjection/AligentS3MediaExtensionTest.php
+++ b/src/Tests/Unit/DependencyInjection/AligentS3MediaExtensionTest.php
@@ -9,7 +9,9 @@
  */
 namespace Aligent\S3MediaBundle\Tests\Unit\DependencyInjection;
 
+use Aligent\S3MediaBundle\Cache\OroCacheAdapter;
 use Aligent\S3MediaBundle\DependencyInjection\AligentS3MediaExtension;
+use Aligent\S3MediaBundle\Provider\ChainCredentialsProvider;
 use Oro\Bundle\TestFrameworkBundle\Test\DependencyInjection\ExtensionTestCase;
 
 class AligentS3MediaExtensionTest extends ExtensionTestCase
@@ -21,9 +23,8 @@ class AligentS3MediaExtensionTest extends ExtensionTestCase
         // Services
         $expectedDefinitions = [
             'aligent_s3.cache',
-            'aligent_s3.cache_adapter',
-            'aligent_s3.credentials_provider.chain',
-            'aligent_s3.credentials_provider.chain',
+            OroCacheAdapter::class,
+            ChainCredentialsProvider::class,
             'aligent_s3.credentials',
             'aligent_s3.credentials_provider.ecs',
             'aligent_s3.credentials_provider.key',


### PR DESCRIPTION
Hi!

The branch I'm proposing to merge here adds Oro Platform 5.1 compatibility.  Major changes:

- Bumped composer deps to allow use with Oro Platform 5.1.
- Re-jigged credentials caching.  Previously implemented by gluing together `Aws\DoctrineCacheAdapter` and Oro's cache.  However, in 5.1 the `TraceableAdapter` no longer implements the interfaces necessary to satisfy the `DoctrineCacheAdapter` type hints.  So I've implemented a new `OroCacheAdapter` class that's functionally equivalent to the old `DoctrineCacheAdapter` and uses Oro's cache pools correctly.
- Some slightly newer Symfony conventions in `services.yml` and corresponding updates to DI pass.  Note: Also fixed typo in tag here.

You'll probably want to create a new `5.1` branch for this, but I can't propose a PR to a branch that doesn't exist yet! :)
